### PR TITLE
feat!: `count!` macro which returns `[_; N]` or `Vec<_>`.

### DIFF
--- a/ashen/src/packfile/mod.rs
+++ b/ashen/src/packfile/mod.rs
@@ -64,7 +64,7 @@ impl PackFile {
             Ok((input, EntryHeader { offset, size }))
         }
 
-        multi::count(entry_header, total_entries as usize)(input)
+        multi::count!(entry_header, total_entries as usize)(input)
     }
 
     #[allow(clippy::unnecessary_wraps)] // TODO(Unavailable): Rewrite using nom

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -1,3 +1,7 @@
+// Discussion about possible future alternatives:
+// https://github.com/rust-lang/rust/pull/101179
+#![feature(maybe_uninit_uninit_array_transpose)]
+
 pub mod asset;
 pub mod directory;
 pub mod error;

--- a/engine/src/utils/nom.rs
+++ b/engine/src/utils/nom.rs
@@ -4,6 +4,7 @@
 
 macro_rules! re_export {
     ($path:ident) => {
+        #[doc = concat!("Re-exports all `nom::", stringify!($path), "::complete` items.")]
         pub mod $path {
             pub use nom::$path::complete::*;
         }
@@ -15,29 +16,99 @@ re_export!(bytes);
 re_export!(character);
 re_export!(number);
 
+/// Re-exports all `nom::multi` items.
 pub mod multi {
     pub use nom::multi::*;
 
-    // TODO(nenikitov): Find a better way to do it without using 3 generics so we don't have to call with `_, _, _`
-    // Maybe remove `I` and `E` because we are only using `&[u8]` input and our own error type.
-    pub fn count_const<const COUNT: usize, I, O, E>(
-        mut f: impl nom::Parser<I, O, E>,
-    ) -> impl FnMut(I) -> nom::IResult<I, [O; COUNT], E>
-    where
-        I: Clone + PartialEq,
-        E: nom::error::ParseError<I>,
-    {
-        let mut f = nom::multi::count(f, COUNT);
-        move |i: I| {
-            let (i, items) = f(i)?;
-            match items.try_into() {
-                Ok(items) => Ok((i, items)),
-                Err(_) => unreachable!(),
-            }
+    /// Runs the embedded parser `count` times, gathering the results in `[O; N]`
+    /// or `Vec<O>`.
+    ///
+    /// # Array
+    ///
+    /// If the macro is called with a single parameter (the nom parser), then an
+    /// array with a inferred `N` (count) would be returned e.g:
+    ///
+    /// ```
+    /// use engine::utils::nom::{Result, multi, number};
+    ///
+    /// fn parse_u32s<const COUNT: usize>(input: &[u8]) -> Result<[u32; COUNT]> {
+    ///     // N is infered by the function return type ([u32; COUNT]).
+    ///     multi::count!(|i| number::le_u32(i))(input)
+    /// }
+    ///
+    /// let input = [42, 0, 0, 0, 69, 0, 0, 0];
+    ///
+    /// assert_eq!(parse_u32s(&input).unwrap(), ([].as_slice(), [42, 69]));
+    /// assert!(parse_u32s::<3>(&input).is_err());
+    /// ```
+    ///
+    /// # Vec
+    ///
+    /// If the second parameter (count) is provided when calling the macro, a
+    /// `Vec<_>` of **exactly** `count` elements would be returned.
+    #[macro_export]
+    #[doc(hidden)] // `macro_export` puts the macro at the root of the crate.
+    macro_rules! __count {
+        // [_; N] (infers N by context).
+        ($fn:expr) => {
+            $crate::utils::nom::__array_count($fn)
+        };
+        // Vec<_> (it contains **exactly** `$count` elements).
+        ($fn:expr, $count:expr) => {
+            $crate::utils::nom::multi::count($fn, $count)
+        };
+    }
+
+    // prevents from conflicting with the actual `nom::multi::count` item.
+    pub use __count as count;
+}
+
+#[doc(hidden)]
+pub fn __array_count<'i, const N: usize, O>(
+    f: impl Fn(Input<'i>) -> Result<'i, O>,
+) -> impl FnMut(Input<'i>) -> Result<'i, [O; N]> {
+    use std::mem::MaybeUninit;
+
+    move |mut input| {
+        let mut elements = MaybeUninit::<[O; N]>::uninit().transpose();
+
+        for (idx, elem) in elements.iter_mut().enumerate() {
+            match f(input) {
+                Ok((__input, output)) => {
+                    elem.write(output);
+                    input = __input;
+                }
+                Err(e) => {
+                    // Dropping a `MaybeUninit` does nothing, if an error occurs,
+                    // already allocated elements should be dropped manually to
+                    // prevent memory leaks.
+                    for elem in &mut elements[..idx] {
+                        // SAFETY: elements.iter_mut().next() was called at least
+                        // `idx - 1` times.
+                        unsafe { elem.assume_init_drop() }
+                    }
+
+                    return Err(e);
+                }
+            };
         }
+
+        let elements = elements.transpose();
+
+        // SAFETY: elements.iter_mut ensures that `f` was called for each element
+        // without failing, which means that every element should be initialized.
+        Ok((input, unsafe { MaybeUninit::assume_init(elements) }))
     }
 }
 
+/// The input type used through the crate's API.
 pub type Input<'a> = &'a [u8];
 
-pub type Result<'a, T> = nom::IResult<Input<'a>, T, crate::error::ParseError>;
+/// All nom parsers implement this trait.
+pub trait Parser<'a, O>: nom::Parser<Input<'a>, O, crate::error::ParseError> {}
+
+// "trait alias"es to an specific impl of `nom::Parser`.
+impl<'a, T, O> Parser<'a, O> for T where T: nom::Parser<Input<'a>, O, crate::error::ParseError> {}
+
+/// Holds the result of parsing functions.
+pub type Result<'a, O> = nom::IResult<Input<'a>, O, crate::error::ParseError>;


### PR DESCRIPTION
Didn't really liked that we needed 2 different functions when the return type was the only thing that semantically was different. I guess the only disadvantage of this, is that you can't no longer specify the generic parameters, but that should not be an issue; the same `input` and `error` types are used through the crate's API, so there should not be any inference problems.

refactor: avoid heap allocations when calling `count_const`.

count_const, renamed to `__array_count`, now uses MaybeUninit to allocate a fixed array, instead of calling `try_into` on a vector.

docs: document all the `utils::nom` items.

BREAKING CHANGE: count_const is now private