### PR TITLE
refactor: move away from workspace lints.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,14 +4,3 @@ members = [
     "ashen",
     "engine",
 ]
-
-[workspace.lints.rust]
-unused = "allow"
-unused_imports = "warn"
-
-[workspace.lints.clippy]
-pedantic = "warn"
-default_trait_access = "allow"
-module_name_repetitions = "allow"
-must_use_candidate = "allow"
-wildcard_imports = "allow"

--- a/ashen/Cargo.toml
+++ b/ashen/Cargo.toml
@@ -3,9 +3,6 @@ name = "ashen"
 version = "0.1.0"
 edition = "2021"
 
-[lints]
-workspace = true
-
 [dependencies]
 engine = { path = "../engine/" }
 flate2 = "1.0.28"

--- a/ashen/src/packfile/mod.rs
+++ b/ashen/src/packfile/mod.rs
@@ -28,7 +28,7 @@ impl PackFile {
     pub fn new(input: &[u8]) -> Result<Self> {
         let (copyright, entries) = {
             let (input, (copyright, total_entries)) = Self::header(input)?;
-            let (input, (headers)) = Self::entry_headers(input, total_entries)?;
+            let (_input, headers) = Self::entry_headers(input, total_entries)?;
             (copyright, headers)
         };
         let (input, entries) = Self::entries(input, &entries)?;
@@ -52,14 +52,14 @@ impl PackFile {
     fn entry_headers(input: &[u8], total_entries: u32) -> Result<Vec<EntryHeader>> {
         fn entry_header(input: &[u8]) -> Result<EntryHeader> {
             // TODO(nenikitov): add check for `asset_kind == 0`
-            let (input, asset_kind) = number::le_u32(input)?;
+            let (input, _asset_kind) = number::le_u32(input)?;
 
             let (input, offset) = number::le_u32(input)?;
 
             let (input, size) = number::le_u32(input)?;
 
             // TODO(nenikitov): add check for `reserved == 0`
-            let (input, reserved) = number::le_u32(input)?;
+            let (input, _reserved) = number::le_u32(input)?;
 
             Ok((input, EntryHeader { offset, size }))
         }

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -3,9 +3,6 @@ name = "engine"
 version = "0.1.0"
 edition = "2021"
 
-[lints]
-workspace = true
-
 [dependencies]
 flate2 = "1.0.28"
 itertools = "0.12.0"

--- a/engine/src/asset/pack_info.rs
+++ b/engine/src/asset/pack_info.rs
@@ -1,6 +1,5 @@
 use super::AssetChunk;
 use crate::utils::nom::*;
-use nom::error::{ErrorKind, ParseError};
 use std::ops::Index;
 
 #[derive(Debug)]

--- a/engine/src/asset/skybox.rs
+++ b/engine/src/asset/skybox.rs
@@ -1,4 +1,4 @@
-use super::{Asset, AssetChunk, Extension, Kind};
+use super::{Asset, Extension, Kind};
 use crate::{asset::color_map::Color, error, utils::nom::*};
 use itertools::Itertools;
 
@@ -45,7 +45,7 @@ impl Asset for Skybox {
 mod tests {
     use super::*;
     use crate::utils::{format::*, fs::*};
-    use std::{cell::LazyCell, fs};
+    use std::cell::LazyCell;
 
     const SKYBOX_DATA: LazyCell<Vec<u8>> = deflated!("19C57C.dat");
 

--- a/engine/src/asset/sound/dat/t_effect.rs
+++ b/engine/src/asset/sound/dat/t_effect.rs
@@ -1,5 +1,3 @@
-use std::io;
-
 use crate::{
     asset::{sound::dat::t_instrument::TSampleParsed, AssetChunk},
     utils::nom::*,

--- a/engine/src/asset/sound/dat/t_instrument.rs
+++ b/engine/src/asset/sound/dat/t_instrument.rs
@@ -1,13 +1,7 @@
-use std::io::{self, Cursor};
-
 use crate::{
-    asset::{pack_info::PackInfo, sound::dat::mixer::Mixer, AssetChunk},
+    asset::AssetChunk,
     utils::nom::*,
 };
-use itertools::Itertools;
-use lewton::inside_ogg::OggStreamReader;
-
-use super::mixer::SoundEffect;
 
 #[derive(Debug)]
 pub struct TInstrument {

--- a/engine/src/asset/sound/dat/t_instrument.rs
+++ b/engine/src/asset/sound/dat/t_instrument.rs
@@ -1,7 +1,4 @@
-use crate::{
-    asset::AssetChunk,
-    utils::nom::*,
-};
+use crate::{asset::AssetChunk, utils::nom::*};
 
 #[derive(Debug)]
 pub struct TInstrument {

--- a/engine/src/asset/sound/dat/t_song.rs
+++ b/engine/src/asset/sound/dat/t_song.rs
@@ -1,5 +1,3 @@
-use std::io::{self, Cursor};
-
 use crate::{
     asset::{sound::dat::mixer::Mixer, AssetChunk},
     utils::nom::*,

--- a/engine/src/asset/sound/mod.rs
+++ b/engine/src/asset/sound/mod.rs
@@ -2,21 +2,18 @@ mod dat;
 
 use flate2::read::ZlibDecoder;
 use std::{
-    fs,
-    io::{self, Read},
-    ops::Index,
-    path::Path,
+    io::{Read},
 };
 
-use self::dat::{mixer::SoundEffect, t_effect::TEffect};
+use self::dat::{t_effect::TEffect};
 
-use super::{pack_info::PackInfo, Asset, AssetChunk, Extension, Kind};
+use super::{Asset, AssetChunk, Extension, Kind};
 use crate::{
     asset::sound::dat::{
         asset_header::SoundAssetHeader, chunk_header::SoundChunkHeader, t_song::TSong,
     },
-    error::{self, ParseError},
-    utils::{format::*, nom::*},
+    error::{self},
+    utils::{nom::*},
 };
 
 // TODO(nenikitov): Move to utils

--- a/engine/src/asset/sound/mod.rs
+++ b/engine/src/asset/sound/mod.rs
@@ -78,7 +78,7 @@ impl Asset for SoundAssetCollection {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::utils::fs::*;
+    use crate::utils::{format::WaveFile, fs::*};
     use std::{cell::LazyCell, path::PathBuf};
 
     const SOUND_DATA: LazyCell<Vec<u8>> = deflated!("BBC974.dat");

--- a/engine/src/asset/sound/mod.rs
+++ b/engine/src/asset/sound/mod.rs
@@ -1,11 +1,9 @@
 mod dat;
 
 use flate2::read::ZlibDecoder;
-use std::{
-    io::{Read},
-};
+use std::io::Read;
 
-use self::dat::{t_effect::TEffect};
+use self::dat::t_effect::TEffect;
 
 use super::{Asset, AssetChunk, Extension, Kind};
 use crate::{
@@ -13,7 +11,7 @@ use crate::{
         asset_header::SoundAssetHeader, chunk_header::SoundChunkHeader, t_song::TSong,
     },
     error::{self},
-    utils::{nom::*},
+    utils::nom::*,
 };
 
 // TODO(nenikitov): Move to utils

--- a/engine/src/asset/string_table.rs
+++ b/engine/src/asset/string_table.rs
@@ -37,7 +37,7 @@ impl Asset for StringTable {
 mod tests {
     use super::*;
     use crate::utils::fs::*;
-    use std::{cell::LazyCell, fs};
+    use std::cell::LazyCell;
 
     const SPANISH_STRING_TABLE_DATA: LazyCell<Vec<u8>> = deflated!("DA5B9C.dat");
 

--- a/engine/src/directory.rs
+++ b/engine/src/directory.rs
@@ -1,4 +1,4 @@
-use crate::{asset::Asset};
+use crate::asset::Asset;
 
 pub trait Directory {
     // TODO(nenikitov): Return `Option` or `Result`.

--- a/engine/src/directory.rs
+++ b/engine/src/directory.rs
@@ -1,4 +1,4 @@
-use crate::{asset::Asset, utils::nom::Result};
+use crate::{asset::Asset};
 
 pub trait Directory {
     // TODO(nenikitov): Return `Option` or `Result`.

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -1,9 +1,20 @@
-// Discussion about possible future alternatives:
-// https://github.com/rust-lang/rust/pull/101179
-#![feature(maybe_uninit_uninit_array_transpose)]
-#![feature(let_chains)]
-#![feature(lazy_cell)]
-#![feature(io_error_more)]
+#![allow(
+    unused,
+    clippy::cast_lossless,
+    clippy::default_trait_access,
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::wildcard_imports
+)]
+#![warn(clippy::pedantic, unused_imports)]
+#![feature(
+    // Discussion about possible future alternatives:
+    // https://github.com/rust-lang/rust/pull/101179
+    maybe_uninit_uninit_array_transpose,
+    let_chains,
+    lazy_cell,
+    io_error_more
+)]
 
 pub mod asset;
 pub mod directory;

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -1,12 +1,12 @@
+#![warn(clippy::pedantic)]
 #![allow(
     unused,
-    clippy::cast_lossless,
     clippy::default_trait_access,
     clippy::module_name_repetitions,
     clippy::must_use_candidate,
     clippy::wildcard_imports
 )]
-#![warn(clippy::pedantic, unused_imports)]
+#![warn(unused_imports)]
 #![feature(
     // Discussion about possible future alternatives:
     // https://github.com/rust-lang/rust/pull/101179

--- a/engine/src/utils/mod.rs
+++ b/engine/src/utils/mod.rs
@@ -34,8 +34,6 @@ pub mod fs {
     }
 
     use std::{fs, io, path::Path};
-
-    
 }
 
 pub mod format {

--- a/engine/src/utils/mod.rs
+++ b/engine/src/utils/mod.rs
@@ -35,7 +35,7 @@ pub mod fs {
 
     use std::{fs, io, path::Path};
 
-    pub(crate) use {deflated, workspace_file};
+    
 }
 
 pub mod format {

--- a/engine/src/utils/mod.rs
+++ b/engine/src/utils/mod.rs
@@ -1,6 +1,9 @@
 pub mod nom;
 
 pub mod fs {
+    use std::path::Path;
+    use std::{fs, io};
+
     /// Gets a path relative to the workspace directory.
     macro_rules! workspace_file {
         ($file:expr) => {
@@ -33,7 +36,8 @@ pub mod fs {
         inner(path.as_ref(), contents.as_ref())
     }
 
-    use std::{fs, io, path::Path};
+    #[allow(unused)]
+    pub(crate) use {deflated, workspace_file};
 }
 
 pub mod format {


### PR DESCRIPTION
They don't work particularly when you need for example `allow(unused)` and `warn(unused_imports)` at the same time.