### PR TITLE
Fix!/packfile automatic decompression

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,10 @@ File parsing is in test suite only, for now.
         ```sh
         cargo test --release -- --ignored parse_rom_packfile
         ```
-    - This will split and deflate game files into `output/deflated/` directory
-    - Files are named with the address as they appear in the [asset table](#file-structure)
+    - This will split and deflate game files into `output/deflated/` directory.
+    - Files are named with the address as they appear in the [asset table](#file-structure).
+    - Files that begin with decompression signature are automatically decompressed and named with `-deflated` suffix.
+        This automatic decompression doesn't work well for collection assets such as textures.
 - Parse resources (make sure to unpack first)
     1. Run parsing tests
         ```sh

--- a/engine/src/asset/model/mod.rs
+++ b/engine/src/asset/model/mod.rs
@@ -94,7 +94,7 @@ mod tests {
     };
 
     const COLOR_MAP_DATA: LazyCell<Vec<u8>> = deflated_file!("01.dat");
-    const MODEL_DATA: LazyCell<Vec<u8>> = deflated_file!("0E.dat");
+    const MODEL_DATA: LazyCell<Vec<u8>> = deflated_file!("0E-deflated.dat");
 
     #[test]
     #[ignore = "uses Ashen ROM files"]

--- a/engine/src/asset/pack_file.rs
+++ b/engine/src/asset/pack_file.rs
@@ -1,8 +1,6 @@
 //! This only works with the last version of Ashen :).
 
 use crate::utils::nom::*;
-use flate2::read::ZlibDecoder;
-use std::io::Read;
 
 #[derive(Debug, PartialEq)]
 struct EntryHeader {
@@ -74,22 +72,10 @@ impl PackFile {
     ) -> Result<'a, Vec<EntryData>> {
         fn entry(input: &[u8], entry_header: &EntryHeader) -> EntryData {
             let bytes = &input[entry_header.offset as usize..][..entry_header.size as usize];
-            let bytes = if let [b'Z', b'L', s1, s2, s3, bytes @ ..] = bytes {
-                let size = u32::from_le_bytes([*s1, *s2, *s3, 0]);
 
-                let mut decoder = ZlibDecoder::new(bytes);
-                let mut data = Vec::with_capacity(size as usize);
-                decoder
-                    .read_to_end(&mut data)
-                    .expect("Data should be a valid zlib stream");
-                // TODO(nenikitov): Check if `data.len() == size`
-
-                data
-            } else {
-                bytes.to_vec()
-            };
-
-            EntryData { bytes }
+            EntryData {
+                bytes: bytes.to_vec(),
+            }
         }
 
         let entries = entry_headers.iter().map(|h| entry(input, h)).collect();
@@ -100,9 +86,9 @@ impl PackFile {
 
 #[cfg(test)]
 mod tests {
-    use std::{cell::LazyCell, path::PathBuf};
+    use std::{cell::LazyCell, io, path::PathBuf};
 
-    use crate::utils::test::*;
+    use crate::utils::{compression::decompress, test::*};
 
     use super::*;
 
@@ -160,16 +146,13 @@ mod tests {
                 // File 1
                 b'A', b's', b'h', b'e', b'n',
                 // File 2
-                b'Z', b'L', // Asset Zlib signature
-                0x06, 0x00, 0x00, // Stream size
-                0x78, 0xDA, // Actual Zlib signature
-                0x73, 0x2C, 0xCE, 0x48, 0xCD, 0xE3, 0x02, 0x00, 0x07, 0x80, 0x01, 0xFA,
+                b'Z', b'L',
             ],
             &[
                 EntryHeader { offset: 0, size: 5 },
                 EntryHeader {
                     offset: 5,
-                    size: 19,
+                    size: 2,
                 },
             ],
         )?;
@@ -181,7 +164,7 @@ mod tests {
                     bytes: b"Ashen".to_vec(),
                 },
                 EntryData {
-                    bytes: b"Ashen\n".to_vec(),
+                    bytes: b"ZL".to_vec(),
                 }
             ]
         );
@@ -204,9 +187,20 @@ mod tests {
             .entries
             .iter()
             .enumerate()
-            .try_for_each(|(i, entry)| {
-                let file = output_dir.join(format!("{i:0>2X}.dat"));
-                output_file(file, &entry.bytes)
+            .try_for_each(|(i, entry)| -> io::Result<()> {
+                let compressed = &entry.bytes;
+                let decompressed = &decompress(&entry.bytes);
+
+                output_file(output_dir.join(format!("{i:0>2X}.dat")), &entry.bytes)?;
+
+                if compressed != decompressed {
+                    output_file(
+                        output_dir.join(format!("{i:0>2X}-deflated.dat")),
+                        &decompress(&entry.bytes),
+                    )?;
+                }
+
+                Ok(())
             })?;
 
         Ok(())

--- a/engine/src/asset/sound/mod.rs
+++ b/engine/src/asset/sound/mod.rs
@@ -1,8 +1,5 @@
 mod dat;
 
-use flate2::read::ZlibDecoder;
-use std::io::Read;
-
 use self::dat::t_effect::TEffect;
 
 use super::{Asset, AssetChunk, Extension, Kind};
@@ -11,26 +8,8 @@ use crate::{
         asset_header::SoundAssetHeader, chunk_header::SoundChunkHeader, t_song::TSong,
     },
     error,
-    utils::nom::*,
+    utils::{nom::*, compression::decompress},
 };
-
-// TODO(nenikitov): Move to utils
-// TODO(nenikitov): Return `Result`
-fn deflate(input: &[u8]) -> Vec<u8> {
-    if let [b'Z', b'L', s1, s2, s3, bytes @ ..] = input {
-        let size = u32::from_le_bytes([*s1, *s2, *s3, 0]);
-
-        let mut decoder = ZlibDecoder::new(bytes);
-        let mut data = Vec::with_capacity(size as usize);
-        decoder
-            .read_to_end(&mut data)
-            .expect("Data should be a valid zlib stream");
-
-        data
-    } else {
-        input.to_vec()
-    }
-}
 
 pub struct SoundAssetCollection {
     songs: Vec<TSong>,
@@ -56,7 +35,7 @@ impl Asset for SoundAssetCollection {
                 let songs = songs
                     .infos
                     .into_iter()
-                    .map(|s| deflate(&input[s]))
+                    .map(|s| decompress(&input[s]))
                     .map(|s| TSong::parse(s.as_slice()).map(|(_, d)| d))
                     .collect::<std::result::Result<Vec<_>, _>>()?;
 
@@ -64,7 +43,7 @@ impl Asset for SoundAssetCollection {
                 let effects = effects
                     .infos
                     .into_iter()
-                    .map(|s| deflate(&input[s]))
+                    .map(|s| decompress(&input[s]))
                     .map(|s| TEffect::parse(s.as_slice()).map(|(_, d)| d))
                     .collect::<std::result::Result<Vec<_>, _>>()?;
 

--- a/engine/src/asset/sound/mod.rs
+++ b/engine/src/asset/sound/mod.rs
@@ -8,7 +8,7 @@ use crate::{
         asset_header::SoundAssetHeader, chunk_header::SoundChunkHeader, t_song::TSong,
     },
     error,
-    utils::{nom::*, compression::decompress},
+    utils::{compression::decompress, nom::*},
 };
 
 pub struct SoundAssetCollection {

--- a/engine/src/asset/string_table.rs
+++ b/engine/src/asset/string_table.rs
@@ -39,7 +39,7 @@ mod tests {
     use crate::utils::test::*;
     use std::cell::LazyCell;
 
-    const STRING_TABLE_DATA: LazyCell<Vec<u8>> = deflated_file!("98.dat");
+    const STRING_TABLE_DATA: LazyCell<Vec<u8>> = deflated_file!("98-deflated.dat");
 
     #[test]
     #[ignore = "uses Ashen ROM files"]

--- a/engine/src/utils/compression.rs
+++ b/engine/src/utils/compression.rs
@@ -1,0 +1,39 @@
+use std::io::Read;
+
+use flate2::bufread::ZlibDecoder;
+
+// TODO(nenikitov): Return `Result`
+pub fn decompress(bytes: &[u8]) -> Vec<u8> {
+    match bytes {
+        [b'Z', b'L', s1, s2, s3, bytes @ ..] => {
+            let size = u32::from_le_bytes([*s1, *s2, *s3, 0]);
+            let mut decoder = ZlibDecoder::new(bytes);
+            let mut data = Vec::with_capacity(size as usize);
+            decoder
+                .read_to_end(&mut data)
+                .expect("Data should be a valid zlib stream");
+
+            // TODO(nenikitov): Check if `data.len() == size`
+
+            data
+        }
+        _ => bytes.to_vec(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decompress_zlib_works() {
+        let data = [
+            b'Z', b'L', // Asset Zlib signature
+            0x06, 0x00, 0x00, // Stream size
+            0x78, 0xDA, // Actual Zlib signature
+            0x73, 0x2C, 0xCE, 0x48, 0xCD, 0xE3, 0x02, 0x00, 0x07, 0x80, 0x01, 0xFA,
+        ];
+
+        assert_eq!("Ashen\n".bytes().collect::<Vec<u8>>(), decompress(&data))
+    }
+}

--- a/engine/src/utils/mod.rs
+++ b/engine/src/utils/mod.rs
@@ -1,3 +1,4 @@
+pub mod compression;
 pub mod format;
 pub mod nom;
 #[cfg(test)]


### PR DESCRIPTION
There is a problem with automatic decompression.

Texture data, as far as `PackFile` header concerned, is a single asset. In reality, texture data is a bunch of textures one after another. This becomes an issue if the first texture is compressed (which it is in the ROM) because automatic decompression only sees the first texture and disregards the next ones.

This PR removes automatic decompression. It's assets or directory's job to decompress resources before parsing.

This PR also modifies format of the output of the `parse_rom_packfile` test.