### PR TITLE
Refactor/texture inside model and skybox

### DIFF
--- a/engine/src/asset/skybox.rs
+++ b/engine/src/asset/skybox.rs
@@ -1,13 +1,15 @@
-use super::{extension::*, AssetParser};
+use super::{
+    extension::*,
+    texture::dat::{size::TextureSize, texture::Texture},
+    AssetParser,
+};
 use crate::{asset::color_map::Color, utils::nom::*};
-use itertools::Itertools;
 
 const COLOR_COUNT: usize = 256;
 
-#[derive(Debug)]
 pub struct Skybox {
     pub palette: Vec<Color>,
-    pub texture: Vec<Vec<u8>>,
+    pub texture: Texture,
 }
 
 impl AssetParser<Pack> for Skybox {
@@ -24,13 +26,10 @@ impl AssetParser<Pack> for Skybox {
             let (input, palette) = multi::count!(number::le_u16, 256)(input)?;
             let palette: Vec<_> = palette.into_iter().map(Color::from_12_bit).collect();
 
-            let (input, texture) = multi::count!(number::le_u8, (width * height) as usize)(input)?;
-            let texture = texture
-                .into_iter()
-                .chunks(width as usize)
-                .into_iter()
-                .map(Iterator::collect)
-                .collect();
+            let (_, texture) = Texture::parser(TextureSize {
+                width: width as usize,
+                height: height as usize,
+            })(input)?;
 
             Ok((&[], Self { palette, texture }))
         }

--- a/engine/src/asset/texture/dat/size.rs
+++ b/engine/src/asset/texture/dat/size.rs
@@ -2,22 +2,14 @@ use std::ops::Div;
 
 #[derive(Clone, Copy)]
 pub struct TextureSize {
-    pub width: u16,
-    pub height: u16,
+    pub width: usize,
+    pub height: usize,
 }
 
-impl Div<u16> for TextureSize {
+impl Div<usize> for TextureSize {
     type Output = Self;
 
-    fn div(self, rhs: u16) -> Self::Output {
-        &self / rhs
-    }
-}
-
-impl Div<u16> for &TextureSize {
-    type Output = TextureSize;
-
-    fn div(self, rhs: u16) -> Self::Output {
+    fn div(self, rhs: usize) -> Self::Output {
         TextureSize {
             width: self.width / rhs,
             height: self.height / rhs,

--- a/engine/src/asset/texture/dat/texture.rs
+++ b/engine/src/asset/texture/dat/texture.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use itertools::Itertools;
 
+// TODO(nenikitov): Move this to a separate public module later
 #[derive(Clone)]
 pub struct Texture {
     pub colors: Vec<Vec<u8>>,

--- a/engine/src/asset/texture/dat/texture.rs
+++ b/engine/src/asset/texture/dat/texture.rs
@@ -21,15 +21,12 @@ impl AssetParser<Wildcard> for Texture {
     type Context<'ctx> = TextureSize;
 
     fn parser(size: Self::Context<'_>) -> impl Fn(Input) -> Result<Self::Output> {
-        let width = size.width as usize;
-        let height = size.height as usize;
-
         move |input| {
-            let (input, colors) = multi::count!(number::le_u8, width * height)(input)?;
+            let (input, colors) = multi::count!(number::le_u8, size.width * size.height)(input)?;
 
             let colors = colors
                 .into_iter()
-                .chunks(width)
+                .chunks(size.width)
                 .into_iter()
                 .map(Iterator::collect)
                 .collect();

--- a/engine/src/asset/texture/mod.rs
+++ b/engine/src/asset/texture/mod.rs
@@ -1,7 +1,8 @@
+// TODO(nenikitov): When textures are moved to a separate public module later,
+// this `pub(crate)` could be deleted
 pub(crate) mod dat;
 
 use self::dat::texture::Texture;
-
 use super::{extension::*, AssetParser};
 use crate::utils::{compression::decompress, nom::*};
 use dat::{offset::TextureOffset, size::TextureSize, texture::MippedTexture};

--- a/engine/src/asset/texture/mod.rs
+++ b/engine/src/asset/texture/mod.rs
@@ -1,4 +1,4 @@
-mod dat;
+pub(crate) mod dat;
 
 use self::dat::texture::Texture;
 
@@ -48,8 +48,8 @@ impl AssetParser<Pack> for MippedTextureCollection {
                     let input = decompress(input);
 
                     MippedTexture::parser(TextureSize {
-                        width: o.width,
-                        height: o.height,
+                        width: o.width as usize,
+                        height: o.height as usize,
                     })(&input)
                     .map(|(_, d)| (d, o))
                 })


### PR DESCRIPTION
We have some duplicated code to parse indexed textures inside models and skyboxes. This PR reuses `Texture` `AssetParser` logic to parse those sections.